### PR TITLE
add windows support

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,5 +20,8 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '8.0.212'
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.5'
       - name: Build and test
         run: ./gradlew build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,7 +151,8 @@ tasks.named("check").get().dependsOn(ktlintTask)
 // Build echo plugin binary for tests
 val buildEchoPlugin = tasks.register<Exec>("buildEchoPlugin") {
     workingDir = File("${project.rootDir}/src/test/go")
-    commandLine = listOf("go", "build", "-o", "${project.buildDir}/go/echo", "./echo")
+    outputs.dir("${project.buildDir}/go")
+    commandLine = listOf("go", "build", "-o", "${project.buildDir}/go", "./echo")
 }
 
 tasks.named("test").get().dependsOn(buildEchoPlugin)

--- a/src/main/kotlin/io/titandata/plugin/PluginProvider.kt
+++ b/src/main/kotlin/io/titandata/plugin/PluginProvider.kt
@@ -23,9 +23,8 @@ abstract class PluginProvider(val pluginDirectory: String) {
     )
 
     fun startProcess(pluginName: String, magicCookieKey: String, magicCookieValue: String): Process {
-        val builder = ProcessBuilder("./$pluginName")
+        val builder = ProcessBuilder("$pluginDirectory${File.separator}$pluginName")
                 .redirectError(ProcessBuilder.Redirect.INHERIT)
-                .directory(File(pluginDirectory))
         val env = builder.environment()
         env[magicCookieKey] = magicCookieValue
 


### PR DESCRIPTION
## Proposed Changes

While we only need plugins on linux, for development purposes it's nice if the tests will work on Windows. This requires generating the file with a ".exe" extension (the go default), and not relying on setting the current directory (relative paths apparently don't work on Windows).

## Testing

`gradle build`